### PR TITLE
fix: update python poetry installer

### DIFF
--- a/images/ubuntu-20.04/provision_root.sh
+++ b/images/ubuntu-20.04/provision_root.sh
@@ -118,7 +118,7 @@ apt-get install -y goreleaser
 go install github.com/magefile/mage@latest
 
 # poetry
-curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
+curl -sSL https://install.python-poetry.org | python3 -
 
 # Cleanup
 apt-get autoremove -y


### PR DESCRIPTION
Python poetry failed to install because the installer script changed url. This fixes it and installs fine!

```
    default: Retrieving Poetry metadata
    default: 
    default: This installer is deprecated, and scheduled for removal from the Poetry repository on or after January 1, 2023.
    default: See https://github.com/python-poetry/poetry/issues/6377 for details.
    default: 
    default: You should migrate to https://install.python-poetry.org instead, which supports all versions of Poetry, and allows for `self update` of versions 1.1.7 or newer.
    default: Instructions are available at https://python-poetry.org/docs/#installation.
    default: 
    default: Without an explicit version, this installer will attempt to install the latest version of Poetry.
    default: This installer cannot install Poetry 1.2.0a1 or newer (and installs will be unable to `self update` to 1.2.0a1 or newer).
    default: 
    default: To continue to use this deprecated installer, you must specify an explicit version with --version <version> or POETRY_VERSION=<version>.
    default: Alternatively, if you wish to force this deprecated installer to use the latest installable release, set GET_POETRY_IGNORE_DEPRECATION=1.
    default: 
    default: Version 1.2.0 is not supported by this installer! Please specify a version prior to 1.2.0a1 to continue!
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```